### PR TITLE
Add support for hipchat notifier plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tmp
 *.o
 *.a
 mkmf.log
+.vagrant

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Monitor systemd units and trigger alerts for failed states. The command line tool runs as a daemon, using dbus to get notifications of changes to systemd services. If a service enters a failed state, or returns from a failed state to an active state, notifications will be triggered.
 
-Built-in notifications include email and slack, but more can be added via the ruby API.
+Built-in notifications include email, slack, and hipchat, but more can be added via the ruby API.
 
 It works by subscribing to DBus notifications from Systemd. This means that there is no polling, and no busy-loops. SystemdMon will sit in the background, happily waiting and using minimal processes.
 
@@ -13,6 +13,7 @@ It works by subscribing to DBus notifications from Systemd. This means that ther
 * Systemd (v204 was used in development)
 * `mail` gem (if email notifier is used)
 * `slack-notifier` gem > 1.0 (if slack notifier is used)
+* `hipchat` (if hipchat notifier is used)
 
 ## Installation
 
@@ -46,6 +47,10 @@ notifiers:
     username: doge
     icon_emoji: ":computer"
     icon_url: "http://example.com/icon"
+  hipchat:
+    token: bigsecrettokenhere
+    room: myroom
+    username: doge
 units:
 - unicorn.service
 - nginx.service

--- a/lib/systemd_mon/notifiers/hipchat.rb
+++ b/lib/systemd_mon/notifiers/hipchat.rb
@@ -1,0 +1,62 @@
+require 'systemd_mon/error'
+require 'systemd_mon/notifiers/base'
+
+begin
+  require 'hipchat'
+rescue LoadError
+  raise SystemdMon::NotifierDependencyError, "The 'hipchat' gem is required by the hipchat notifier"
+end
+
+module SystemdMon::Notifiers
+  class Hipchat < Base
+    def initialize(*)
+      super
+      self.client = ::HipChat::Client.new(
+          options['token'],
+          :api_version => 'v2')
+    end
+
+    def notify_start!(hostname)
+      chat "SystemdMon is starting on #{hostname}",
+           'green'
+    end
+
+    def notify_stop!(hostname)
+      chat "SystemdMon is stopping on #{hostname}",
+           'yellow'
+    end
+
+    def notify!(notification)
+      unit = notification.unit
+      message = "#{notification.type_text}: systemd unit #{unit.name} on #{notification.hostname} #{unit.state_change.status_text}: #{unit.state.active} (#{unit.state.sub})"
+
+      chat message,
+           color(notification.type)
+
+      log "sent hipchat notification"
+    end
+
+  protected
+    attr_accessor :client, :options
+
+    def chat(message, shade)
+      client[options['room']].send(
+        options['username'],
+        message,
+        :color => shade)
+    end
+
+    def color(type)
+      case type
+      when :alert
+        'red'
+      when :warning
+        'yellow'
+      when :info
+        'purple'
+      else
+        'green'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi! First of all, great work on this gem. Very useful tool with a tremendous amount of utility.

I've added support for Hipchat and tested it with my own account and it seems to be working correctly. I've also added examples to the README so this is pretty much just ready to go.

I toyed with the idea of adding the ability to specify an array of users to @-mention in the config yaml but for now I think getting baseline functionality is good enough before expanding the capabilities here.

Cheers!
