### PR TITLE
Support oneshot type services

### DIFF
--- a/lib/systemd_mon/callback_manager.rb
+++ b/lib/systemd_mon/callback_manager.rb
@@ -10,7 +10,7 @@ module SystemdMon
     def start(change_callback, each_state_change_callback)
       loop do
         unit, state = queue.deq
-        Logger.debug { "#{unit} state change: #{state}" }
+        Logger.debug { "#{unit} new state: #{state}" }
         unit_state = states[unit]
         unit_state << state
 

--- a/lib/systemd_mon/callback_manager.rb
+++ b/lib/systemd_mon/callback_manager.rb
@@ -10,7 +10,7 @@ module SystemdMon
     def start(change_callback, each_state_change_callback)
       loop do
         unit, state = queue.deq
-        Logger.debug { state }
+        Logger.debug { "#{unit} state change: #{state}" }
         unit_state = states[unit]
         unit_state << state
 

--- a/lib/systemd_mon/dbus_unit.rb
+++ b/lib/systemd_mon/dbus_unit.rb
@@ -2,16 +2,18 @@ require 'systemd_mon/state'
 
 module SystemdMon
   class DBusUnit
-    attr_reader :name
+    attr_reader :name, :maybe_service_type
 
-    IFACE_UNIT  = "org.freedesktop.systemd1.Unit"
-    IFACE_PROPS = "org.freedesktop.DBus.Properties"
+    IFACE_UNIT    = "org.freedesktop.systemd1.Unit"
+    IFACE_SERVICE = "org.freedesktop.systemd1.Service"
+    IFACE_PROPS   = "org.freedesktop.DBus.Properties"
 
     def initialize(name, path, dbus_object)
       self.name = name
       self.path = path
       self.dbus_object = dbus_object
       prepare_dbus_objects!
+      self.maybe_service_type = service_type
     end
 
     def register_listener!(queue)
@@ -36,19 +38,20 @@ module SystemdMon
     end
 
     def to_s
-      "#{name}"
+      "#{name}" << (maybe_service_type ? " (#{maybe_service_type})" : '')
     end
 
   protected
     attr_accessor :path, :dbus_object, :change_callback, :each_state_change_callback
-    attr_writer   :name
+    attr_writer   :name, :maybe_service_type
 
     def build_state
       State.new(
         property("ActiveState"),
         property("SubState"),
         property("LoadState"),
-        property("UnitFileState")
+        property("UnitFileState"),
+        maybe_service_type
       )
     end
 
@@ -56,6 +59,12 @@ module SystemdMon
       dbus_object.introspect
       self.dbus_object.default_iface = IFACE_PROPS
       self
+    end
+
+    def service_type
+      if dbus_object[IFACE_SERVICE]
+        dbus_object[IFACE_SERVICE]['Type']
+      end
     end
   end
 end

--- a/lib/systemd_mon/dbus_unit.rb
+++ b/lib/systemd_mon/dbus_unit.rb
@@ -35,6 +35,10 @@ module SystemdMon
       dbus_object.Get(IFACE_UNIT, name).first
     end
 
+    def to_s
+      "#{name}"
+    end
+
   protected
     attr_accessor :path, :dbus_object, :change_callback, :each_state_change_callback
     attr_writer   :name

--- a/lib/systemd_mon/state.rb
+++ b/lib/systemd_mon/state.rb
@@ -29,7 +29,7 @@ module SystemdMon
       when 'oneshot'
         [[], []]
       else
-        [%w(enabled), %w(disabled)]
+        [%w(enabled linked-runtime static), %w(disabled)]
       end
     end
 

--- a/lib/systemd_mon/state.rb
+++ b/lib/systemd_mon/state.rb
@@ -28,6 +28,10 @@ module SystemdMon
     def fail?
       any?(&:fail?)
     end
+
+    def to_s
+      @all_states.join(', ')
+    end
   end
 
 end

--- a/lib/systemd_mon/state.rb
+++ b/lib/systemd_mon/state.rb
@@ -32,6 +32,10 @@ module SystemdMon
     def to_s
       @all_states.join(', ')
     end
+
+    def ==(other)
+      @all_states == other.all_states
+    end
   end
 
 end

--- a/lib/systemd_mon/state.rb
+++ b/lib/systemd_mon/state.rb
@@ -6,13 +6,31 @@ module SystemdMon
 
     attr_reader :active, :sub, :loaded, :unit_file, :all_states
 
-    def initialize(active, sub, loaded, unit_file)
+    def initialize(active, sub, loaded, unit_file, type=nil)
       timestamp   = Time.now
-      @active     = StateValue.new("active", active, timestamp, %w(active), %w(inactive failed))
+      @active     = StateValue.new("active", active, timestamp, *active_states(type))
       @sub        = StateValue.new("status", sub, timestamp)
       @loaded     = StateValue.new("loaded", loaded, timestamp, %w(loaded))
-      @unit_file  = StateValue.new("file", unit_file, timestamp, %w(enabled), %w(disabled))
+      @unit_file  = StateValue.new("file", unit_file, timestamp, *file_states(type))
       @all_states = [@active, @sub, @loaded, @unit_file]
+    end
+
+    def active_states(type)
+      case type
+      when 'oneshot'
+        [%w(inactive), %w(failed)]
+      else
+        [%w(active), %w(inactive failed)]
+      end
+    end
+
+    def file_states(type)
+      case type
+      when 'oneshot'
+        [[], []]
+      else
+        [%w(enabled), %w(disabled)]
+      end
     end
 
     def each

--- a/lib/systemd_mon/state_value.rb
+++ b/lib/systemd_mon/state_value.rb
@@ -39,7 +39,7 @@ module SystemdMon
     end
 
     def ==(other)
-      value == other
+      other.is_a?(SystemdMon::StateValue) && value == other.value
     end
 
   protected


### PR DESCRIPTION
This permits the monitor to correctly watch `Type=oneshot` `.service` units that run on a schedule (using `timer` units) much like a cron job. Normal execution of a oneshot job sends an "info" message, failures are captured, and recoveries are detected the same way as persistent services are.

Note that because of the way that systemd thinks about "loaded" units, oneshot services are not loaded (and thus **not** able to be queried with `GetUnit()`) unless systemd has a reason to load them, for example, as a dependency for a timer. As long as the unit is "loaded" by systemd, the daemon can properly bootstrap the DBusUnit objects that it looks for as a result of their presence in the config file.

This also includes a few little `to_s` additions and fixes a small bug in `==` in the `StateValue` class.

Fixes #2
