### PR TITLE
Fixes a crash when units are not available

### DIFF
--- a/lib/systemd_mon/monitor.rb
+++ b/lib/systemd_mon/monitor.rb
@@ -22,14 +22,22 @@ module SystemdMon
     end
 
     def register_unit(unit_name)
-      self.units << dbus_manager.fetch_unit(unit_name)
+      begin
+        self.units << dbus_manager.fetch_unit(unit_name)
+      rescue SystemdMon::UnknownUnitError => e
+        Logger.puts e.message
+      end
       self
     end
 
     def register_units(*unit_names)
       self.units.concat unit_names.flatten.map { |unit_name|
-        dbus_manager.fetch_unit(unit_name)
-      }
+        begin
+          dbus_manager.fetch_unit(unit_name)
+        rescue SystemdMon::UnknownUnitError => e
+          Logger.puts e.message
+        end
+      }.compact
       self
     end
 

--- a/lib/systemd_mon/state_change.rb
+++ b/lib/systemd_mon/state_change.rb
@@ -88,6 +88,7 @@ module SystemdMon
 
     def diff
       @diff ||= zipped.reject { |states|
+        states = states.kind_of?(Array) ? states : [states]
         match = states.first.value
         states.all? { |s| s.value == match }
       }


### PR DESCRIPTION
First commit fixes a crash when units are not available, systemd_mon will not monitor those files at all, but it is preferred to monitoring nothing.

I also received issues where I located errors in the log at boot. Should result in the first state change getting transmitted as well.
