### PR TITLE
Added a handler to generate Desktop Notifications via DBus so you not…

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ notifiers:
     token: bigsecrettokenhere
     room: myroom
     username: doge
+  desktop:
+   start_stop_message: false
+   timeout: 2000
 units:
 - unicorn.service
 - nginx.service

--- a/lib/systemd_mon/notifiers/desktop.rb
+++ b/lib/systemd_mon/notifiers/desktop.rb
@@ -1,0 +1,50 @@
+require 'systemd_mon/error'
+require 'systemd_mon/notifiers/base'
+require 'systemd_mon/formatters/state_table_formatter'
+
+
+module SystemdMon::Notifiers
+  class Desktop < Base
+    bus = DBus::SessionBus.instance
+    not_service = bus.service("org.freedesktop.Notifications")
+    not_object = not_service.object("/org/freedesktop/Notifications")
+    not_object.introspect
+    DesktopNotifier = not_object["org.freedesktop.Notifications"]
+
+    def initialize(*)
+      super
+      if options['start_stop_message']
+        @startstopmessage = true
+      else
+        @startstopmessage = false
+      end
+      if options['timeout']
+        @timeout = timeout
+      else
+        @timeout = 2000
+      end
+    end
+
+
+    def notify_start!(hostname)
+      if @startstopmessage
+        DesktopNotifier.Notify("Systemd_mon", 0, "info", "Started", "", [], {}, @timeout)
+      end
+    end
+
+    def notify_stop!(hostname)
+      if @startstopmessage
+        DesktopNotifier.Notify("Systemd_mon", 0, "info", "Stopped", "", [], {}, @timeout)
+      end
+    end
+
+    def notify!(notification)
+      unit = notification.unit
+      DesktopNotifier.Notify("Systemd_mon", 0, "#{notification.type_text}", "#{unit.name} changed to #{unit.state_change.status_text}", "", [], {}, @timeout)
+    end
+  end
+end
+
+
+
+

--- a/systemd_mon.gemspec
+++ b/systemd_mon.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ruby-dbus", "~> 0.11.0"
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", ">= 1.6"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
…ice automatically that your services have failed.

Hi, wrote a small notifier so that you get a notification on your desktop via the org.freedesktop.Notifications protocol. Planning to use this on both my server and laptop but have different notification requirement. Slack and/or EMail is fine on a server but for my laptop I would rather fast that a service has stopped working so getting a desktop notification seems like a good idea.